### PR TITLE
build.gradle.kts: add ".debug" suffix for debug builds

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -25,6 +25,9 @@ android {
         }
     }
     buildTypes {
+        getByName("debug") {
+            applicationIdSuffix = ".debug"
+        }
         getByName("release") {
             isMinifyEnabled = true
             isShrinkResources = true


### PR DESCRIPTION
This should make it easier to have the official build alongside development builds
