### PR TITLE
Fix own PM history being misrouted to *server* buffer

### DIFF
--- a/app/src/main/java/com/boxlabs/hexdroid/IrcCore.kt
+++ b/app/src/main/java/com/boxlabs/hexdroid/IrcCore.kt
@@ -2484,7 +2484,12 @@ class IrcClient(val config: IrcConfig) {
 						val isPrivate = !isChannel
 
 						// If this PRIVMSG comes from a server prefix (no '!'), route it to *server*.
-						val isServerPrefix = (msg.prefix != null && !msg.prefix.contains('!') && !msg.prefix.contains('@'))
+						// Some networks replay our OWN historical PMs (via CHATHISTORY) with a bare
+						// nick prefix and no !user@host - identical in shape to a real server prefix.
+						// Check nickEquals() first so that case routes to the PM buffer instead of
+						// being misclassified as a server message (our own nick is never a server name).
+						val isServerPrefix = (msg.prefix != null && !msg.prefix.contains('!') && !msg.prefix.contains('@')
+							&& !nickEquals(from, currentNick))
 
 						// For private messages, use the *other party* as the buffer name.
 						val buf = if (isPrivate) {
@@ -2728,7 +2733,11 @@ class IrcClient(val config: IrcConfig) {
 						}
 
 						val isChannel = isChannelName(target)
-						val isServerPrefix = (msg.prefix != null && !msg.prefix.contains('!') && !msg.prefix.contains('@'))
+						// See the PRIVMSG handler above: our own historical NOTICEs can replay with
+						// a bare nick prefix (no !user@host), which would otherwise be misclassified
+						// as a server-originated NOTICE.
+						val isServerPrefix = (msg.prefix != null && !msg.prefix.contains('!') && !msg.prefix.contains('@')
+							&& !nickEquals(from, currentNick))
 
 						// Bouncer pseudo-user NOTICE routing. ZNC replies to /msg *status
 						// commands (and to /znc slash-command wrapper) via NOTICE — without

--- a/app/src/main/java/com/boxlabs/hexdroid/IrcViewModel.kt
+++ b/app/src/main/java/com/boxlabs/hexdroid/IrcViewModel.kt
@@ -2809,7 +2809,7 @@ class IrcViewModel(
             val rt = runtimes[networkId] ?: return@launch
             val client = rt.client
             val myNick = _state.value.connections[networkId]?.myNick ?: _state.value.myNick
-            val key = bufKey(networkId, buffer)
+            val key = resolveBufferKey(networkId, buffer)
 
             // draft/reply is a client-only tag ("+draft/reply")
             // It's permitted whenever message-tags is negotiated. Some servers also


### PR DESCRIPTION
## Summary

When a network replays a user's own historical private messages (e.g. via WeeChat relay backlog, or CHATHISTORY), the replayed line's prefix is often just the bare nick with no `!user@host` - the same shape `isServerPrefix` uses to detect a genuine server-originated message. This caused a user's own PM history to be silently routed into `*server*` instead of the actual PM buffer, while messages from the other party displayed normally in the PM buffer as expected. The end-user symptom: "I only see the other person's messages in a PM, never my own."

Fix: check `nickEquals(from, currentNick)` before falling back to the server-prefix heuristic, in both the `PRIVMSG` and `NOTICE` handlers - the current nick can never legitimately be a server hostname, so this is a safe priority change.

Also fixed a smaller related inconsistency: `sendToBuffer()`'s local echo resolved its buffer key via the raw `bufKey()` instead of the case-fold-aware `resolveBufferKey()` used everywhere incoming messages resolve their buffer key.

## Test plan

- [x] Reproduced against a real network (WeeChat IRC relay backlog with `!echo-message`, `relay.irc.backlog_*` config) - own PM messages confirmed landing in `*server*` before the fix.
- [x] Applied fix, rebuilt, reconnected with a fully cleared client-side history cache, and confirmed the full PM history (both directions) now replays into the correct PM buffer in proper chronological order.
- [x] Confirmed channel buffers were unaffected before and after (channel routing doesn't use this prefix heuristic at all).