### PR TITLE
Fix BOUNCER NETWORK attribute parsing splitting on wrong delimiter

### DIFF
--- a/app/src/main/java/com/boxlabs/hexdroid/IrcCore.kt
+++ b/app/src/main/java/com/boxlabs/hexdroid/IrcCore.kt
@@ -1082,8 +1082,9 @@ data class Notice(
  *    preferable to losing the whole state transition.
  *
  * Note that [attrTokens] should be the message's params from index 2 onward, plus the
- * trailing field split on spaces. See the BOUNCER NETWORK dispatch site in [IrcClient]
- * for the assembly.
+ * trailing field, each split on ';' (soju packs all attrs into one semicolon-joined
+ * field, not separate space-delimited params). See the BOUNCER NETWORK dispatch site
+ * in [IrcClient] for the assembly.
  *
  * Case-fold [s] under the IRC [caseMapping] advertised by ISUPPORT 005.
  *
@@ -3290,10 +3291,15 @@ class IrcClient(val config: IrcConfig) {
 						when (subCmd) {
 							"NETWORK" -> {
 								// BOUNCER NETWORK <id> <attrs> | BOUNCER NETWORK <id> *
+								// Per the soju.im/bouncer-networks spec, <attrs> is a single field of
+								// semicolon-separated key=value pairs (message-tag escaping rules apply
+								// to each value) - NOT space-separated tokens. A raw ';' is always a real
+								// delimiter here (a literal semicolon inside a value is escaped as `\:`,
+								// never as `\;`), so splitting on it needs no escape-awareness.
 								// Parsing extracted to top-level [parseBouncerNetworkAttrs] for unit testability.
 								val networkId = msg.params.getOrNull(1) ?: return
-								val attrTokens = msg.params.drop(2) +
-									listOfNotNull(msg.trailing).flatMap { it.split(' ') }
+								val attrTokens = (msg.params.drop(2) + listOfNotNull(msg.trailing))
+									.flatMap { it.split(';') }
 								send(parseBouncerNetworkAttrs(networkId, attrTokens))
 							}
 							// BOUNCER ADDNETWORK / DELNETWORK / CHANGENETWORK: soju bouncer management commands.


### PR DESCRIPTION
## Summary

The `BOUNCER NETWORK <id> <attrs>` dispatch handler split the attrs field on spaces. Per the `soju.im/bouncer-networks` spec, soju packs all attributes into a single semicolon-separated field (`name=x;host=y;state=z;...`), not separate space-delimited tokens.

Since a real attrs line has no spaces at all, the entire semicolon-joined blob was treated as one `key=value` token: the "key" ended up being whichever attribute happened to appear first in that particular response, and its "value" became the rest of the attrs still joined by literal semicolons (with any `\s` escapes inside that garbage blob still getting decoded to real spaces by `unescapeIrcTagValue`, since that step runs correctly on whatever it's handed).

Because soju doesn't guarantee stable attribute ordering between responses, this produced non-deterministic results: some networks showed a garbled name+all-other-attrs blob, others showed "Unnamed upstream" (when no attribute in their string happened to be named `name`), and which was which changed on every `LISTNETWORKS` refresh.

Fix: split on `;` instead - soju's actual delimiter for this field. This needs no escape-awareness for the split itself, since a literal semicolon inside a value is represented as `\:` (never `\;`) per message-tag escaping rules, so every raw `;` is a genuine attribute separator.

## Test plan

- [x] Reproduced against a live soju bouncer (5 upstream networks) - before the fix, names shuffled between garbled/blank on every refresh.
- [x] Applied fix, rebuilt, reconnected repeatedly: all 5 networks now show correct name/host/state consistently, no shuffling.

## Screenshot
<img width="1220" height="2712" alt="screen3_redacted2" src="https://github.com/user-attachments/assets/36347905-7d7e-4ecd-9403-16676d4100a9" />
