### PR TITLE
Send explicit NAMES on JOIN when no-implicit-names is negotiated

### DIFF
--- a/app/src/main/java/com/boxlabs/hexdroid/IrcCore.kt
+++ b/app/src/main/java/com/boxlabs/hexdroid/IrcCore.kt
@@ -1974,6 +1974,12 @@ class IrcClient(val config: IrcConfig) {
      */
     private val historyRequested = mutableSetOf<String>()
 
+    /**
+     * Channels we've explicitly requested NAMES for in this session (soju.im/no-implicit-names
+     * / draft/no-implicit-names), to avoid re-fetching on rejoin. Keyed by [casefold].
+     */
+    private val namesRequested = mutableSetOf<String>()
+
     /** Per-buffer "history expected until" timestamp, anything older than this is treated as
      *  history rather than live, so we don't re-notify for already-seen messages.
      *  Keyed by [casefold] - see [historyRequested] for why lowercase() is not enough. */
@@ -2854,6 +2860,21 @@ class IrcClient(val config: IrcConfig) {
 							if (nickEquals(nick, currentNick) && !chanHist) {
 								val fold = casefold(chan)
 								joinedChannelCases[fold] = chan
+							}
+
+							// soju.im/no-implicit-names / draft/no-implicit-names: the server won't
+							// send an automatic 353/366 NAMES list on JOIN when this cap is negotiated
+							// (it's requested by default for bouncer connections, see IrcSession's CAP
+							// REQ list). Without an explicit request the nicklist stays empty except
+							// for our own self-JOIN. Skip when chanHist is true for the same reason as
+							// the CHATHISTORY/playback requests below: a JOIN arriving as part of
+							// buffer playback is our prior session, not the current one.
+							if (nickEquals(nick, currentNick)
+								&& !chanHist
+								&& (hasCap("soju.im/no-implicit-names") || hasCap("draft/no-implicit-names"))
+								&& namesRequested.add(casefold(chan))
+							) {
+								sendRaw("NAMES $chan")
 							}
 
 							// IRCv3 chathistory: request recent messages when we (re)join.


### PR DESCRIPTION
## Summary

HexDroid requests `soju.im/no-implicit-names` by default on any bouncer connection (`IrcSession.kt:490`) and also tracks `draft/no-implicit-names`, but nothing in the JOIN handling path ever checks for either capability or sends a compensating `NAMES` request.

Per the cap's purpose, once negotiated the server intentionally skips the automatic `353`/`366` NAMES reply on JOIN (this avoids a full names re-download on every bouncer reconnect - useful for the bouncer's *own* reconnect bookkeeping, but only if the client is expected to ask for NAMES itself when it actually needs the list). Since HexDroid never asks, every channel's nicklist stayed empty except for the JOIN echo of the client's own nick.

Reproduced on two different upstream servers behind the same soju bouncer (one WeeChat-backed, one a plain ircd), confirming this is about the capability itself, not any particular upstream chain.

## Fix

Send `NAMES <channel>` right after a live self-JOIN when either `soju.im/no-implicit-names` or `draft/no-implicit-names` is active - skipped for JOINs arriving as part of bouncer buffer playback (same rationale the existing CHATHISTORY/`znc.in/playback` requests just below already use), and deduped per channel per session with a new `namesRequested` set, mirroring the existing `historyRequested` pattern.

## Test plan

- [x] Reproduced empty nicklists (self only) on two different soju-bound upstreams before the fix.
- [x] Applied fix, rebuilt, reconnected: full nicklists now populate correctly on join for both upstreams.