### PR TITLE
Exempt bouncer connections from public-ircd flood pacing

### DIFF
--- a/app/src/main/java/com/boxlabs/hexdroid/IrcCore.kt
+++ b/app/src/main/java/com/boxlabs/hexdroid/IrcCore.kt
@@ -4702,10 +4702,17 @@ class IrcClient(val config: IrcConfig) {
             // Registration lines are exempt: servers are lenient before 001 and pacing them would
             // slow every connect. A `floodClock` tracks the virtual time by which the queued penalty
             // is "paid"; when it runs more than floodBurstMs ahead of now we wait for it to catch up.
+            //
+            // Bouncer connections are exempt too, for the same reason: a personal soju/ZNC bouncer
+            // isn't a public ircd guarding against flooders, and its own connection to us doesn't
+            // need protecting from OUR traffic. Without this, syncing dozens of channels (each
+            // needing its own JOIN + CHATHISTORY LATEST + WHO) gets throttled at floodPenaltyMs per
+            // line as if we were a stranger flooding a public network - turning a sub-second sync
+            // into minutes for an account with many channels.
             var floodClock = System.currentTimeMillis()
             try {
                 for (unit in outbound) {
-                    if (registered) {
+                    if (registered && !config.isBouncer) {
                         val now = System.currentTimeMillis()
                         if (floodClock < now) floodClock = now
                         if (unit.paced) {


### PR DESCRIPTION
## Summary

The outbound flood pacer (`floodPenaltyMs = 2200L` per line, past an 8s burst budget) applies unconditionally to every connection, including personal soju/ZNC bouncers. A bouncer isn't a public ircd protecting itself from flooders, and its own connection to us doesn't need protecting from our own traffic.

For an account with many channels, syncing on connect needs its own `JOIN` + `CHATHISTORY LATEST` + `WHO` per channel - tens to well over a hundred outbound lines, each throttled as if talking to a stranger on a public network. Measured: **over 3 minutes** of pure artificial delay syncing ~43 channels through a bouncer, versus a couple minutes (and falling further once #49 landed) once traffic wasn't being paced - for comparison, other bouncer-aware clients (Goguma) sync the same account in seconds.

## Fix

Skip pacing for `config.isBouncer` connections, the same way pre-registration lines are already exempt (`if (registered) { ... }` → `if (registered && !config.isBouncer) { ... }`).

## Test plan

- [x] Reproduced multi-minute artificial sync delay against a real soju bouncer with 40+ channels before the fix.
- [x] Applied fix, rebuilt, reconnected: sync completes noticeably faster, with `CHATHISTORY LATEST` firing immediately after `JOIN` instead of being queued behind flood pacing for over a minute.

## Note

While testing this, we found a separate, real ordering issue in channel history replay (unrelated to this PR) that turned out to be server-side - already being looked at by Jordan. Flagging here only for context in case it comes up in review; not part of this change.